### PR TITLE
Fix app restart delay set with arguments

### DIFF
--- a/src/bencoding/android/tools/PlatformProxy.java
+++ b/src/bencoding/android/tools/PlatformProxy.java
@@ -65,15 +65,13 @@ public class PlatformProxy  extends KrollProxy {
 	}
 	
 	@Kroll.method
-	public void restartApp(@Kroll.argument(optional=true) Object delay)
+	public void restartApp(@Kroll.argument(optional=true) String delay)
 	{
 		int pendingIntentID = 999123;
 		long DELAY_OFFSET = 15000;
 		
 		if (delay != null) {
-			if(delay instanceof Long){
-				DELAY_OFFSET = (Long)delay;
-			}
+			DELAY_OFFSET = Long.valueOf(delay);
 	    } 
 		
 		if(TiApplication.getInstance().isDebuggerEnabled()){


### PR DESCRIPTION
Passed Object  is not always long so it is never changed form defaults
