### PR TITLE
define service name within package context

### DIFF
--- a/src/bencoding/android/receivers/BootReceiver.java
+++ b/src/bencoding/android/receivers/BootReceiver.java
@@ -146,11 +146,13 @@ public class BootReceiver  extends BroadcastReceiver{
 	
 	private void bootService(Context context, String bootService, int interval){
 		try{
+			if(bootService.startsWith(".")){
+				bootService = context.getApplicationContext().getPackageName() + bootService;
+			}
 			Intent serviceIntent = new Intent(context,Class.forName(bootService));
-	        serviceIntent.putExtra("interval", interval*1000L); // 10 secs
-	        Common.msgLogger("Starting service "+bootService +" interval "+interval);
-	        context.startService(serviceIntent); 
-	        
+	        	serviceIntent.putExtra("interval", interval*1000L); // 10 secs
+	        	Common.msgLogger("Starting service "+bootService +" interval "+interval);
+	        	context.startService(serviceIntent);
 		} catch (Exception e) {
 			Common.msgLogger(e.toString());
 		}


### PR DESCRIPTION
Add option to define startup service name within package context.
instead of : "com.myapp.MyBootService"
write : ".MyBootService"

Service name will be changed on fly depending on package name